### PR TITLE
use dist-packages as python install dir instad of site-packages

### DIFF
--- a/openrave/CMakeLists.txt
+++ b/openrave/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 add_custom_command(OUTPUT ${OPENRAVE_SOURCE_DIR}
   COMMAND git clone https://github.com/rdiankov/openrave.git ${OPENRAVE_SOURCE_DIR}
   COMMAND cd ${OPENRAVE_SOURCE_DIR} && git reset --hard cdc681631c1ab0dab57d4201475ae02659fa4412 # latest_sable of May 7 2016
+  COMMAND cd ${OPENRAVE_SOURCE_DIR} && patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/python-path.patch # use dist-packages isntead of site-packages
   )
 add_custom_target(download_openrave
   DEPENDS ${OPENRAVE_SOURCE_DIR}

--- a/openrave/python-path.patch
+++ b/openrave/python-path.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abd26cc..de926a1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -117,7 +117,8 @@ if( OPT_PYTHON )
+       OUTPUT_VARIABLE _python_numpy_include OUTPUT_STRIP_TRAILING_WHITESPACE
+       RESULT_VARIABLE _python_failed0)
+     execute_process(
+-      COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; from myrelpath import relpath; print relpath(get_python_lib(1,prefix='${CMAKE_INSTALL_PREFIX}'),'${CMAKE_INSTALL_PREFIX}')"
++      #COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; from myrelpath import relpath; print relpath(get_python_lib(1,prefix='${CMAKE_INSTALL_PREFIX}'),'${CMAKE_INSTALL_PREFIX}')"
++      COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; from myrelpath import relpath; print relpath(get_python_lib(1,prefix='${CMAKE_INSTALL_PREFIX}'),'${CMAKE_INSTALL_PREFIX}').replace('site-packages', 'dist-packages')"
+       OUTPUT_VARIABLE OPENRAVE_PYTHON_INSTALL_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
+       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+       RESULT_VARIABLE _python_failed2)


### PR DESCRIPTION
official opnerave install python library under site-pakcages, but ros assume they are installed undre /opt/ros/indigo/python2.7/dist-packages
